### PR TITLE
Replace 'net' by 'total'

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -66,7 +66,7 @@ contract Exchange is Ownable, Configurable, Validatable, ClientFundable, Communi
         DriipSettlementChallenge newDriipSettlementChallenge);
     event ChangeTradesRevenueFundEvent(RevenueFund oldRevenueFund, RevenueFund newRevenueFund);
     event ChangePaymentsRevenueFundEvent(RevenueFund oldRevenueFund, RevenueFund newRevenueFund);
-    event StageNetFeeEvent(address wallet, int256 deltaAmount, int256 cumulativeAmount, address currencyCt,
+    event StageTotalFeeEvent(address wallet, int256 deltaAmount, int256 cumulativeAmount, address currencyCt,
         uint256 currencyId);
 
     //
@@ -271,7 +271,7 @@ contract Exchange is Ownable, Configurable, Validatable, ClientFundable, Communi
             }
 
             // Stage fees to revenue fund
-            stageFees(wallet, party.fees.net, tradesRevenueFund, trade.nonce);
+            stageFees(wallet, party.fees.total, tradesRevenueFund, trade.nonce);
 
             // If payment nonce is beyond max driip nonce then update max driip nonce
             if (trade.nonce > maxDriipNonce)
@@ -342,13 +342,13 @@ contract Exchange is Ownable, Configurable, Validatable, ClientFundable, Communi
             else
                 settlement.target.done = true;
 
-            MonetaryTypes.Figure[] memory netFees;
+            MonetaryTypes.Figure[] memory totalFees;
             int256 currentBalance;
             if (NahmiiTypes.isPaymentSender(payment, wallet)) {
-                netFees = payment.sender.fees.net;
+                totalFees = payment.sender.fees.total;
                 currentBalance = payment.sender.balances.current;
             } else {
-                netFees = payment.recipient.fees.net;
+                totalFees = payment.recipient.fees.total;
                 currentBalance = payment.recipient.balances.current;
             }
 
@@ -368,7 +368,7 @@ contract Exchange is Ownable, Configurable, Validatable, ClientFundable, Communi
             }
 
             // Stage fees to revenue fund
-            stageFees(wallet, netFees, paymentsRevenueFund, payment.nonce);
+            stageFees(wallet, totalFees, paymentsRevenueFund, payment.nonce);
 
             // If payment nonce is beyond max driip nonce then update max driip nonce
             if (payment.nonce > maxDriipNonce)
@@ -469,7 +469,7 @@ contract Exchange is Ownable, Configurable, Validatable, ClientFundable, Communi
                 walletCurrencyFeeCharged[wallet][fees[i].currency.ct][fees[i].currency.id] = fees[i].amount;
 
                 // Emit event
-                emit StageNetFeeEvent(wallet,
+                emit StageTotalFeeEvent(wallet,
                     fees[i].amount - walletCurrencyFeeCharged[wallet][fees[i].currency.ct][fees[i].currency.id],
                     walletCurrencyFeeCharged[wallet][fees[i].currency.ct][fees[i].currency.id],
                     fees[i].currency.ct, fees[i].currency.id);

--- a/contracts/FraudChallengeByPaymentSucceedingTrade.sol
+++ b/contracts/FraudChallengeByPaymentSucceedingTrade.sol
@@ -74,7 +74,7 @@ contract FraudChallengeByPaymentSucceedingTrade is Ownable, FraudChallengable, C
 
         require(
             !validator.isGenuineSuccessiveTradePaymentBalances(trade, tradePartyRole, tradeCurrencyRole, payment, paymentPartyRole) ||
-        !validator.isGenuineSuccessiveTradePaymentNetFees(trade, tradePartyRole, payment)
+        !validator.isGenuineSuccessiveTradePaymentTotalFees(trade, tradePartyRole, payment)
         );
 
         configuration.setOperationalModeExit();

--- a/contracts/FraudChallengeBySuccessivePayments.sol
+++ b/contracts/FraudChallengeBySuccessivePayments.sol
@@ -66,7 +66,7 @@ contract FraudChallengeBySuccessivePayments is Ownable, FraudChallengable, Chall
 
         require(
             !validator.isGenuineSuccessivePaymentsBalances(firstPayment, firstPaymentPartyRole, lastPayment, lastPaymentPartyRole) ||
-        !validator.isGenuineSuccessivePaymentsNetFees(firstPayment, lastPayment)
+        !validator.isGenuineSuccessivePaymentsTotalFees(firstPayment, lastPayment)
         );
 
         configuration.setOperationalModeExit();

--- a/contracts/FraudChallengeBySuccessiveTrades.sol
+++ b/contracts/FraudChallengeBySuccessiveTrades.sol
@@ -76,7 +76,7 @@ contract FraudChallengeBySuccessiveTrades is Ownable, FraudChallengable, Challen
 
         require(
             !validator.isGenuineSuccessiveTradesBalances(firstTrade, firstTradePartyRole, firstTradeCurrencyRole, lastTrade, lastTradePartyRole, lastTradeCurrencyRole) ||
-        !validator.isGenuineSuccessiveTradesNetFees(firstTrade, firstTradePartyRole, lastTrade, lastTradePartyRole)
+        !validator.isGenuineSuccessiveTradesTotalFees(firstTrade, firstTradePartyRole, lastTrade, lastTradePartyRole)
         );
 
         configuration.setOperationalModeExit();

--- a/contracts/FraudChallengeByTradeSucceedingPayment.sol
+++ b/contracts/FraudChallengeByTradeSucceedingPayment.sol
@@ -74,7 +74,7 @@ contract FraudChallengeByTradeSucceedingPayment is Ownable, FraudChallengable, C
 
         require(
             !validator.isGenuineSuccessivePaymentTradeBalances(payment, paymentPartyRole, trade, tradePartyRole, tradeCurrencyRole) ||
-        !validator.isGenuineSuccessivePaymentTradeNetFees(payment, paymentPartyRole, trade, tradePartyRole)
+        !validator.isGenuineSuccessivePaymentTradeTotalFees(payment, paymentPartyRole, trade, tradePartyRole)
         );
 
         configuration.setOperationalModeExit();

--- a/contracts/Hasher.sol
+++ b/contracts/Hasher.sol
@@ -132,8 +132,8 @@ contract Hasher is Ownable {
                 trade.buyer.fees.single.amount,
                 trade.buyer.fees.single.currency.ct,
                 trade.buyer.fees.single.currency.id
-            // TODO Consider adding dynamic size 'trade.buyer.fees.net' to hash
-            // trade.buyer.fees.net
+            // TODO Consider adding dynamic size 'trade.buyer.fees.total' to hash
+            // trade.buyer.fees.total
             ));
     }
 
@@ -156,17 +156,17 @@ contract Hasher is Ownable {
                 trade.seller.fees.single.amount,
                 trade.seller.fees.single.currency.ct,
                 trade.seller.fees.single.currency.id
-            // TODO Consider adding dynamic size 'trade.seller.fees.net' to hash
-            // trade.seller.fees.net
+            // TODO Consider adding dynamic size 'trade.seller.fees.total' to hash
+            // trade.seller.fees.total
             ));
     }
 
     function hashTradeTransfersData(NahmiiTypes.Trade trade) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(
                 trade.transfers.intended.single,
-                trade.transfers.intended.net,
+                trade.transfers.intended.total,
                 trade.transfers.conjugate.single,
-                trade.transfers.conjugate.net
+                trade.transfers.conjugate.total
             ));
     }
 
@@ -208,7 +208,7 @@ contract Hasher is Ownable {
     function hashPaymentTransfersData(NahmiiTypes.Payment payment) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(
                 payment.transfers.single,
-                payment.transfers.net
+                payment.transfers.total
             ));
     }
 

--- a/contracts/NahmiiChallenge.sol
+++ b/contracts/NahmiiChallenge.sol
@@ -59,7 +59,7 @@ contract NahmiiChallenge is Challenge {
         stgTradeParty.liquidityRole = memTradeParty.liquidityRole;
         stgTradeParty.order = memTradeParty.order;
         stgTradeParty.balances = memTradeParty.balances;
-        copySingleFigureNetFigures(stgTradeParty.fees, memTradeParty.fees);
+        copySingleFigureTotalFigures(stgTradeParty.fees, memTradeParty.fees);
     }
 
     function copyPaymentSenderParty(NahmiiTypes.PaymentSenderParty storage stgPaymentParty,
@@ -69,7 +69,7 @@ contract NahmiiChallenge is Challenge {
         stgPaymentParty.nonce = memPaymentParty.nonce;
         stgPaymentParty.wallet = memPaymentParty.wallet;
         stgPaymentParty.balances = memPaymentParty.balances;
-        copySingleFigureNetFigures(stgPaymentParty.fees, memPaymentParty.fees);
+        copySingleFigureTotalFigures(stgPaymentParty.fees, memPaymentParty.fees);
     }
 
     function copyPaymentRecipientParty(NahmiiTypes.PaymentRecipientParty storage stgPaymentParty,
@@ -79,15 +79,15 @@ contract NahmiiChallenge is Challenge {
         stgPaymentParty.nonce = memPaymentParty.nonce;
         stgPaymentParty.wallet = memPaymentParty.wallet;
         stgPaymentParty.balances = memPaymentParty.balances;
-        copyFigureArray(stgPaymentParty.fees.net, memPaymentParty.fees.net);
+        copyFigureArray(stgPaymentParty.fees.total, memPaymentParty.fees.total);
     }
 
-    function copySingleFigureNetFigures(NahmiiTypes.SingleFigureNetFigures storage stgSingleFigureNetFigures,
-        NahmiiTypes.SingleFigureNetFigures memSingleFigureNetFigures)
+    function copySingleFigureTotalFigures(NahmiiTypes.SingleFigureTotalFigures storage stgSingleFigureTotalFigures,
+        NahmiiTypes.SingleFigureTotalFigures memSingleFigureTotalFigures)
     private
     {
-        stgSingleFigureNetFigures.single = memSingleFigureNetFigures.single;
-        copyFigureArray(stgSingleFigureNetFigures.net, memSingleFigureNetFigures.net);
+        stgSingleFigureTotalFigures.single = memSingleFigureTotalFigures.single;
+        copyFigureArray(stgSingleFigureTotalFigures.total, memSingleFigureTotalFigures.total);
     }
 
     function copyFigureArray(MonetaryTypes.Figure[] storage stgFigureArr, MonetaryTypes.Figure[] memFigureArr)

--- a/contracts/NahmiiTypes.sol
+++ b/contracts/NahmiiTypes.sol
@@ -34,13 +34,13 @@ library NahmiiTypes {
         MonetaryTypes.Currency conjugate;
     }
 
-    struct SingleFigureNetFigures {
+    struct SingleFigureTotalFigures {
         MonetaryTypes.Figure single;
-        MonetaryTypes.Figure[] net;
+        MonetaryTypes.Figure[] total;
     }
 
-    struct NetFigures {
-        MonetaryTypes.Figure[] net;
+    struct TotalFigures {
+        MonetaryTypes.Figure[] total;
     }
 
     struct CurrentPreviousInt256 {
@@ -48,9 +48,9 @@ library NahmiiTypes {
         int256 previous;
     }
 
-    struct SingleNetInt256 {
+    struct SingleTotalInt256 {
         int256 single;
-        int256 net;
+        int256 total;
     }
 
     struct IntendedConjugateCurrentPreviousInt256 {
@@ -58,9 +58,9 @@ library NahmiiTypes {
         CurrentPreviousInt256 conjugate;
     }
 
-    struct IntendedConjugateSingleNetInt256 {
-        SingleNetInt256 intended;
-        SingleNetInt256 conjugate;
+    struct IntendedConjugateSingleTotalInt256 {
+        SingleTotalInt256 intended;
+        SingleTotalInt256 conjugate;
     }
 
     struct WalletExchangeHashes {
@@ -102,7 +102,7 @@ library NahmiiTypes {
 
         IntendedConjugateCurrentPreviousInt256 balances;
 
-        SingleFigureNetFigures fees;
+        SingleFigureTotalFigures fees;
     }
 
     struct Trade {
@@ -117,7 +117,7 @@ library NahmiiTypes {
 
         // Positive intended transfer is always in direction from seller to buyer
         // Positive conjugate transfer is always in direction from buyer to seller
-        IntendedConjugateSingleNetInt256 transfers;
+        IntendedConjugateSingleTotalInt256 transfers;
 
         Seal seal;
         uint256 blockNumber;
@@ -129,7 +129,7 @@ library NahmiiTypes {
 
         CurrentPreviousInt256 balances;
 
-        SingleFigureNetFigures fees;
+        SingleFigureTotalFigures fees;
     }
 
     struct PaymentRecipientParty {
@@ -138,7 +138,7 @@ library NahmiiTypes {
 
         CurrentPreviousInt256 balances;
 
-        NetFigures fees;
+        TotalFigures fees;
     }
 
     struct Payment {
@@ -151,7 +151,7 @@ library NahmiiTypes {
         PaymentRecipientParty recipient;
 
         // Positive transfer is always in direction from sender to recipient
-        SingleNetInt256 transfers;
+        SingleTotalInt256 transfers;
 
         WalletExchangeSeal seals;
         uint256 blockNumber;

--- a/contracts/Validator.sol
+++ b/contracts/Validator.sol
@@ -306,7 +306,7 @@ contract Validator is Ownable, AccessorManageable, Configurable, Hashable {
         return lastCurrentPreviousBalances.previous == firstCurrentPreviousBalances.current;
     }
 
-    function isGenuineSuccessiveTradesNetFees(
+    function isGenuineSuccessiveTradesTotalFees(
         NahmiiTypes.Trade firstTrade,
         NahmiiTypes.TradePartyRole firstTradePartyRole,
         NahmiiTypes.Trade lastTrade,
@@ -322,13 +322,13 @@ contract Validator is Ownable, AccessorManageable, Configurable, Hashable {
         else if (NahmiiTypes.TradePartyRole.Seller == lastTradePartyRole)
             lastSingleFee = lastTrade.seller.fees.single;
 
-        MonetaryTypes.Figure[] memory firstNetFees = (NahmiiTypes.TradePartyRole.Buyer == firstTradePartyRole ? firstTrade.buyer.fees.net : firstTrade.seller.fees.net);
-        MonetaryTypes.Figure memory firstNetFee = MonetaryTypes.getFigureByCurrency(firstNetFees, lastSingleFee.currency);
+        MonetaryTypes.Figure[] memory firstTotalFees = (NahmiiTypes.TradePartyRole.Buyer == firstTradePartyRole ? firstTrade.buyer.fees.total : firstTrade.seller.fees.total);
+        MonetaryTypes.Figure memory firstTotalFee = MonetaryTypes.getFigureByCurrency(firstTotalFees, lastSingleFee.currency);
 
-        MonetaryTypes.Figure[] memory lastNetFees = (NahmiiTypes.TradePartyRole.Buyer == lastTradePartyRole ? lastTrade.buyer.fees.net : lastTrade.seller.fees.net);
-        MonetaryTypes.Figure memory lastNetFee = MonetaryTypes.getFigureByCurrency(lastNetFees, lastSingleFee.currency);
+        MonetaryTypes.Figure[] memory lastTotalFees = (NahmiiTypes.TradePartyRole.Buyer == lastTradePartyRole ? lastTrade.buyer.fees.total : lastTrade.seller.fees.total);
+        MonetaryTypes.Figure memory lastTotalFee = MonetaryTypes.getFigureByCurrency(lastTotalFees, lastSingleFee.currency);
 
-        return lastNetFee.amount == firstNetFee.amount.add(lastSingleFee.amount);
+        return lastTotalFee.amount == firstTotalFee.amount.add(lastSingleFee.amount);
     }
 
     function isGenuineSuccessiveTradeOrderResiduals(
@@ -347,7 +347,7 @@ contract Validator is Ownable, AccessorManageable, Configurable, Hashable {
         return firstCurrentResiduals == lastPreviousResiduals;
     }
 
-    function isGenuineSuccessivePaymentsNetFees(
+    function isGenuineSuccessivePaymentsTotalFees(
         NahmiiTypes.Payment firstPayment,
         NahmiiTypes.Payment lastPayment
     )
@@ -355,12 +355,12 @@ contract Validator is Ownable, AccessorManageable, Configurable, Hashable {
     pure
     returns (bool)
     {
-        MonetaryTypes.Figure memory firstNetFee = MonetaryTypes.getFigureByCurrency(firstPayment.sender.fees.net, lastPayment.sender.fees.single.currency);
-        MonetaryTypes.Figure memory lastNetFee = MonetaryTypes.getFigureByCurrency(lastPayment.sender.fees.net, lastPayment.sender.fees.single.currency);
-        return lastNetFee.amount == firstNetFee.amount.add(lastPayment.sender.fees.single.amount);
+        MonetaryTypes.Figure memory firstTotalFee = MonetaryTypes.getFigureByCurrency(firstPayment.sender.fees.total, lastPayment.sender.fees.single.currency);
+        MonetaryTypes.Figure memory lastTotalFee = MonetaryTypes.getFigureByCurrency(lastPayment.sender.fees.total, lastPayment.sender.fees.single.currency);
+        return lastTotalFee.amount == firstTotalFee.amount.add(lastPayment.sender.fees.single.amount);
     }
 
-    function isGenuineSuccessiveTradePaymentNetFees(
+    function isGenuineSuccessiveTradePaymentTotalFees(
         NahmiiTypes.Trade trade,
         NahmiiTypes.TradePartyRole tradePartyRole,
         NahmiiTypes.Payment payment
@@ -369,15 +369,15 @@ contract Validator is Ownable, AccessorManageable, Configurable, Hashable {
     pure
     returns (bool)
     {
-        MonetaryTypes.Figure[] memory firstNetFees = (NahmiiTypes.TradePartyRole.Buyer == tradePartyRole ? trade.buyer.fees.net : trade.seller.fees.net);
-        MonetaryTypes.Figure memory firstNetFee = MonetaryTypes.getFigureByCurrency(firstNetFees, payment.sender.fees.single.currency);
+        MonetaryTypes.Figure[] memory firstTotalFees = (NahmiiTypes.TradePartyRole.Buyer == tradePartyRole ? trade.buyer.fees.total : trade.seller.fees.total);
+        MonetaryTypes.Figure memory firstTotalFee = MonetaryTypes.getFigureByCurrency(firstTotalFees, payment.sender.fees.single.currency);
 
-        MonetaryTypes.Figure memory lastNetFee = MonetaryTypes.getFigureByCurrency(payment.sender.fees.net, payment.sender.fees.single.currency);
+        MonetaryTypes.Figure memory lastTotalFee = MonetaryTypes.getFigureByCurrency(payment.sender.fees.total, payment.sender.fees.single.currency);
 
-        return lastNetFee.amount == firstNetFee.amount.add(payment.sender.fees.single.amount);
+        return lastTotalFee.amount == firstTotalFee.amount.add(payment.sender.fees.single.amount);
     }
 
-    function isGenuineSuccessivePaymentTradeNetFees(
+    function isGenuineSuccessivePaymentTradeTotalFees(
         NahmiiTypes.Payment payment,
         NahmiiTypes.PaymentPartyRole paymentPartyRole,
         NahmiiTypes.Trade trade,
@@ -393,13 +393,13 @@ contract Validator is Ownable, AccessorManageable, Configurable, Hashable {
         else if (NahmiiTypes.TradePartyRole.Seller == tradePartyRole)
             lastSingleFee = trade.seller.fees.single;
 
-        MonetaryTypes.Figure[] memory firstNetFees = (NahmiiTypes.PaymentPartyRole.Sender == paymentPartyRole ? payment.sender.fees.net : payment.recipient.fees.net);
-        MonetaryTypes.Figure memory firstNetFee = MonetaryTypes.getFigureByCurrency(firstNetFees, lastSingleFee.currency);
+        MonetaryTypes.Figure[] memory firstTotalFees = (NahmiiTypes.PaymentPartyRole.Sender == paymentPartyRole ? payment.sender.fees.total : payment.recipient.fees.total);
+        MonetaryTypes.Figure memory firstTotalFee = MonetaryTypes.getFigureByCurrency(firstTotalFees, lastSingleFee.currency);
 
-        MonetaryTypes.Figure[] memory lastNetFees = (NahmiiTypes.TradePartyRole.Buyer == tradePartyRole ? trade.buyer.fees.net : trade.seller.fees.net);
-        MonetaryTypes.Figure memory lastNetFee = MonetaryTypes.getFigureByCurrency(lastNetFees, lastSingleFee.currency);
+        MonetaryTypes.Figure[] memory lastTotalFees = (NahmiiTypes.TradePartyRole.Buyer == tradePartyRole ? trade.buyer.fees.total : trade.seller.fees.total);
+        MonetaryTypes.Figure memory lastTotalFee = MonetaryTypes.getFigureByCurrency(lastTotalFees, lastSingleFee.currency);
 
-        return lastNetFee.amount == firstNetFee.amount.add(lastSingleFee.amount);
+        return lastTotalFee.amount == firstTotalFee.amount.add(lastSingleFee.amount);
     }
 
     //

--- a/contracts/test/MockedValidator.sol
+++ b/contracts/test/MockedValidator.sol
@@ -45,16 +45,16 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
     bool[] paymentSeals;
     bool successiveTradesPartyNonces;
     bool successiveTradesBalances;
-    bool successiveTradesNetFees;
+    bool successiveTradesTotalFees;
     bool successivePaymentsPartyNonces;
     bool successivePaymentsBalances;
-    bool successivePaymentsNetFees;
+    bool successivePaymentsTotalFees;
     bool successiveTradePaymentPartyNonces;
     bool successiveTradePaymentBalances;
-    bool successiveTradePaymentNetFees;
+    bool successiveTradePaymentTotalFees;
     bool successivePaymentTradePartyNonces;
     bool successivePaymentTradeBalances;
-    bool successivePaymentTradeNetFees;
+    bool successivePaymentTradeTotalFees;
     bool successiveTradeOrderResiduals;
     bool walletSignature;
 
@@ -96,16 +96,16 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         paymentSeals.push(true);
         successiveTradesPartyNonces = true;
         successiveTradesBalances = true;
-        successiveTradesNetFees = true;
+        successiveTradesTotalFees = true;
         successivePaymentsPartyNonces = true;
         successivePaymentsBalances = true;
-        successivePaymentsNetFees = true;
+        successivePaymentsTotalFees = true;
         successiveTradePaymentPartyNonces = true;
         successiveTradePaymentBalances = true;
-        successiveTradePaymentNetFees = true;
+        successiveTradePaymentTotalFees = true;
         successivePaymentTradePartyNonces = true;
         successivePaymentTradeBalances = true;
-        successivePaymentTradeNetFees = true;
+        successivePaymentTradeTotalFees = true;
         successiveTradeOrderResiduals = true;
         walletSignature = true;
 
@@ -331,11 +331,11 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         return successiveTradesBalances;
     }
 
-    function setGenuineSuccessiveTradesNetFees(bool genuine) public {
-        successiveTradesNetFees = genuine;
+    function setGenuineSuccessiveTradesTotalFees(bool genuine) public {
+        successiveTradesTotalFees = genuine;
     }
 
-    function isGenuineSuccessiveTradesNetFees(
+    function isGenuineSuccessiveTradesTotalFees(
         NahmiiTypes.Trade firstTrade,
         NahmiiTypes.TradePartyRole firstTradePartyRole,
         NahmiiTypes.Trade lastTrade,
@@ -350,7 +350,7 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         require(firstTradePartyRole == firstTradePartyRole);
         require(lastTrade.nonce == lastTrade.nonce);
         require(lastTradePartyRole == lastTradePartyRole);
-        return successiveTradesNetFees;
+        return successiveTradesTotalFees;
     }
 
     function setSuccessivePaymentsPartyNonces(bool genuine) public {
@@ -397,11 +397,11 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         return successivePaymentsBalances;
     }
 
-    function setGenuineSuccessivePaymentsNetFees(bool genuine) public {
-        successivePaymentsNetFees = genuine;
+    function setGenuineSuccessivePaymentsTotalFees(bool genuine) public {
+        successivePaymentsTotalFees = genuine;
     }
 
-    function isGenuineSuccessivePaymentsNetFees(
+    function isGenuineSuccessivePaymentsTotalFees(
         NahmiiTypes.Payment firstPayment,
         NahmiiTypes.Payment lastPayment
     )
@@ -412,7 +412,7 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         // To silence unused function parameter compiler warning
         require(firstPayment.nonce == firstPayment.nonce);
         require(lastPayment.nonce == lastPayment.nonce);
-        return successivePaymentsNetFees;
+        return successivePaymentsTotalFees;
     }
 
     function setSuccessiveTradePaymentPartyNonces(bool genuine) public {
@@ -461,11 +461,11 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         return successiveTradePaymentBalances;
     }
 
-    function setGenuineSuccessiveTradePaymentNetFees(bool genuine) public {
-        successiveTradePaymentNetFees = genuine;
+    function setGenuineSuccessiveTradePaymentTotalFees(bool genuine) public {
+        successiveTradePaymentTotalFees = genuine;
     }
 
-    function isGenuineSuccessiveTradePaymentNetFees(
+    function isGenuineSuccessiveTradePaymentTotalFees(
         NahmiiTypes.Trade trade,
         NahmiiTypes.TradePartyRole tradePartyRole,
         NahmiiTypes.Payment payment
@@ -478,7 +478,7 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         require(trade.nonce == trade.nonce);
         require(tradePartyRole == tradePartyRole);
         require(payment.nonce == payment.nonce);
-        return successiveTradePaymentNetFees;
+        return successiveTradePaymentTotalFees;
     }
 
     function setSuccessivePaymentTradePartyNonces(bool genuine) public {
@@ -527,11 +527,11 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         return successivePaymentTradeBalances;
     }
 
-    function setGenuineSuccessivePaymentTradeNetFees(bool genuine) public {
-        successivePaymentTradeNetFees = genuine;
+    function setGenuineSuccessivePaymentTradeTotalFees(bool genuine) public {
+        successivePaymentTradeTotalFees = genuine;
     }
 
-    function isGenuineSuccessivePaymentTradeNetFees(
+    function isGenuineSuccessivePaymentTradeTotalFees(
         NahmiiTypes.Payment payment,
         NahmiiTypes.PaymentPartyRole paymentPartyRole,
         NahmiiTypes.Trade trade,
@@ -546,7 +546,7 @@ contract MockedValidator is Ownable, AccessorManageable /*, Validator*/ {
         require(paymentPartyRole == paymentPartyRole);
         require(trade.nonce == trade.nonce);
         require(tradePartyRole == tradePartyRole);
-        return successivePaymentTradeNetFees;
+        return successivePaymentTradeTotalFees;
     }
 
     function setGenuineSuccessiveTradeOrderResiduals(bool genuine) public {

--- a/docs/Exchange.md
+++ b/docs/Exchange.md
@@ -18,7 +18,7 @@ Params:
 1. **owner** *of type `address`*
 
 ## Events
-### StageNetFeeEvent(address,int256,int256,address,uint256)
+### StageTotalFeeEvent(address,int256,int256,address,uint256)
 
 
 **Execution cost**: No bound available

--- a/docs/Validator.md
+++ b/docs/Validator.md
@@ -97,7 +97,7 @@ Params:
 
 
 --- 
-### isGenuineSuccessivePaymentTradeNetFees(tuple,uint8,tuple,uint8)
+### isGenuineSuccessivePaymentTradeTotalFees(tuple,uint8,tuple,uint8)
 
 
 **Execution cost**: No bound available
@@ -675,7 +675,7 @@ Returns:
 1. **output_0** *of type `bool`*
 
 --- 
-### isGenuineSuccessiveTradesNetFees(tuple,uint8,tuple,uint8)
+### isGenuineSuccessiveTradesTotalFees(tuple,uint8,tuple,uint8)
 
 
 **Execution cost**: No bound available
@@ -716,7 +716,7 @@ Returns:
 1. **output_0** *of type `bool`*
 
 --- 
-### isGenuineSuccessiveTradePaymentNetFees(tuple,uint8,tuple)
+### isGenuineSuccessiveTradePaymentTotalFees(tuple,uint8,tuple)
 
 
 **Execution cost**: No bound available
@@ -759,7 +759,7 @@ Returns:
 1. **output_0** *of type `bool`*
 
 --- 
-### isGenuineSuccessivePaymentsNetFees(tuple,tuple)
+### isGenuineSuccessivePaymentsTotalFees(tuple,tuple)
 
 
 **Execution cost**: No bound available
@@ -1171,7 +1171,7 @@ Returns:
 
 
 --- 
-### isGenuineSuccessivePaymentTradeNetFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
+### isGenuineSuccessivePaymentTradeTotalFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
 
 
 **Execution cost**: No bound available
@@ -1189,7 +1189,7 @@ Returns:
 
 
 --- 
-### isGenuineSuccessivePaymentsNetFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
+### isGenuineSuccessivePaymentsTotalFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
 
 
 **Execution cost**: No bound available
@@ -1216,7 +1216,7 @@ Returns:
 
 
 --- 
-### isGenuineSuccessiveTradePaymentNetFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
+### isGenuineSuccessiveTradePaymentTotalFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
 
 
 **Execution cost**: No bound available
@@ -1234,7 +1234,7 @@ Returns:
 
 
 --- 
-### isGenuineSuccessiveTradesNetFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
+### isGenuineSuccessiveTradesTotalFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
 
 
 **Execution cost**: No bound available

--- a/docs/test/MockedValidator.md
+++ b/docs/test/MockedValidator.md
@@ -88,7 +88,7 @@ Returns:
 1. **output_0** *of type `bool`*
 
 --- 
-### isGenuineSuccessivePaymentTradeNetFees(tuple,uint8,tuple,uint8)
+### isGenuineSuccessivePaymentTradeTotalFees(tuple,uint8,tuple,uint8)
 
 
 **Execution cost**: No bound available
@@ -125,7 +125,7 @@ Returns:
 1. **output_0** *of type `bool`*
 
 --- 
-### isGenuineSuccessiveTradesNetFees(tuple,uint8,tuple,uint8)
+### isGenuineSuccessiveTradesTotalFees(tuple,uint8,tuple,uint8)
 
 
 **Execution cost**: No bound available
@@ -319,7 +319,7 @@ Returns:
 1. **output_0** *of type `address`*
 
 --- 
-### isGenuineSuccessivePaymentsNetFees(tuple,tuple)
+### isGenuineSuccessivePaymentsTotalFees(tuple,tuple)
 
 
 **Execution cost**: No bound available
@@ -528,7 +528,7 @@ Returns:
 1. **output_0** *of type `bool`*
 
 --- 
-### isGenuineSuccessiveTradePaymentNetFees(tuple,uint8,tuple)
+### isGenuineSuccessiveTradePaymentTotalFees(tuple,uint8,tuple)
 
 
 **Execution cost**: No bound available
@@ -939,7 +939,7 @@ Params:
 
 
 --- 
-### setGenuineSuccessivePaymentTradeNetFees(bool)
+### setGenuineSuccessivePaymentTradeTotalFees(bool)
 
 
 **Execution cost**: less than 22110 gas
@@ -1059,7 +1059,7 @@ Params:
 
 
 --- 
-### setGenuineSuccessiveTradePaymentNetFees(bool)
+### setGenuineSuccessiveTradePaymentTotalFees(bool)
 
 
 **Execution cost**: less than 21142 gas
@@ -1071,7 +1071,7 @@ Params:
 
 
 --- 
-### setGenuineSuccessivePaymentsNetFees(bool)
+### setGenuineSuccessivePaymentsTotalFees(bool)
 
 
 **Execution cost**: less than 21692 gas
@@ -1095,7 +1095,7 @@ Params:
 
 
 --- 
-### setGenuineSuccessiveTradesNetFees(bool)
+### setGenuineSuccessiveTradesTotalFees(bool)
 
 
 **Execution cost**: less than 20680 gas
@@ -1348,7 +1348,7 @@ Params:
 
 
 --- 
-### isGenuineSuccessivePaymentTradeNetFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
+### isGenuineSuccessivePaymentTradeTotalFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
 
 
 **Execution cost**: No bound available
@@ -1366,7 +1366,7 @@ Params:
 
 
 --- 
-### isGenuineSuccessivePaymentsNetFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
+### isGenuineSuccessivePaymentsTotalFees((uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256),(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
 
 
 **Execution cost**: No bound available
@@ -1393,7 +1393,7 @@ Params:
 
 
 --- 
-### isGenuineSuccessiveTradePaymentNetFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
+### isGenuineSuccessiveTradePaymentTotalFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,(address,uint256),(uint256,address,(int256,int256),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,(int256,int256),((int256,(address,uint256))[])),(int256,int256),((bytes32,(bytes32,bytes32,uint8)),(bytes32,(bytes32,bytes32,uint8))),uint256))
 
 
 **Execution cost**: No bound available
@@ -1411,7 +1411,7 @@ Params:
 
 
 --- 
-### isGenuineSuccessiveTradesNetFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
+### isGenuineSuccessiveTradesTotalFees((uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8,(uint256,int256,((address,uint256),(address,uint256)),int256,(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),(uint256,address,uint256,uint8,(int256,(bytes32,bytes32),(int256,int256)),((int256,int256),(int256,int256)),((int256,(address,uint256)),(int256,(address,uint256))[])),((int256,int256),(int256,int256)),(bytes32,(bytes32,bytes32,uint8)),uint256),uint8)
 
 
 **Execution cost**: No bound available

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -102,7 +102,7 @@ exports.mockTrade = async (operator, params) => {
                         id: utils.bigNumberify(0)
                     }
                 },
-                net: [
+                total: [
                     {
                         amount: utils.parseUnits('0.2', 18),
                         currency: {
@@ -147,7 +147,7 @@ exports.mockTrade = async (operator, params) => {
                         id: utils.bigNumberify(0)
                     }
                 },
-                net: [
+                total: [
                     {
                         amount: utils.parseUnits('0.0004', 18),
                         currency: {
@@ -161,11 +161,11 @@ exports.mockTrade = async (operator, params) => {
         transfers: {
             intended: {
                 single: utils.parseUnits('100', 18),
-                net: utils.parseUnits('200', 18)
+                total: utils.parseUnits('200', 18)
             },
             conjugate: {
                 single: utils.parseUnits('0.1', 18),
-                net: utils.parseUnits('0.2', 18)
+                total: utils.parseUnits('0.2', 18)
             }
         },
         blockNumber: utils.bigNumberify(0)
@@ -202,7 +202,7 @@ exports.mockPayment = async (operator, params) => {
                         id: utils.bigNumberify(0)
                     }
                 },
-                net: [
+                total: [
                     {
                         amount: utils.parseUnits('0.2', 18),
                         currency: {
@@ -221,7 +221,7 @@ exports.mockPayment = async (operator, params) => {
                 previous: utils.parseUnits('19600', 18)
             },
             fees: {
-                net: [
+                total: [
                     // {
                     //     amount: utils.parseUnits('0.0', 18),
                     //     currency: {
@@ -234,7 +234,7 @@ exports.mockPayment = async (operator, params) => {
         },
         transfers: {
             single: utils.parseUnits('100', 18),
-            net: utils.parseUnits('200', 18)
+            total: utils.parseUnits('200', 18)
         },
         blockNumber: utils.bigNumberify(0)
     }, params);
@@ -388,8 +388,8 @@ exports.hashTrade = (trade) => {
         trade.buyer.fees.single.amount,
         trade.buyer.fees.single.currency.ct,
         trade.buyer.fees.single.currency.id
-        // TODO Consider adding dynamic size 'trade.buyer.fees.net' to hash
-        // trade.buyer.fees.net
+        // TODO Consider adding dynamic size 'trade.buyer.fees.total' to hash
+        // trade.buyer.fees.total
     );
     const sellerHash = cryptography.hash(
         trade.seller.nonce,
@@ -409,14 +409,14 @@ exports.hashTrade = (trade) => {
         trade.seller.fees.single.amount,
         trade.seller.fees.single.currency.ct,
         trade.seller.fees.single.currency.id
-        // TODO Consider adding dynamic size 'trade.seller.fees.net' to hash
-        // trade.seller.fees.net
+        // TODO Consider adding dynamic size 'trade.seller.fees.total' to hash
+        // trade.seller.fees.total
     );
     const transfersHash = cryptography.hash(
         trade.transfers.intended.single,
-        trade.transfers.intended.net,
+        trade.transfers.intended.total,
         trade.transfers.conjugate.single,
-        trade.transfers.conjugate.net
+        trade.transfers.conjugate.total
     );
     return cryptography.hash(globalHash, buyerHash, sellerHash, transfersHash);
 };
@@ -453,19 +453,19 @@ exports.hashPaymentAsOperator = (payment) => {
         payment.sender.fees.single.amount,
         payment.sender.fees.single.currency.ct,
         payment.sender.fees.single.currency.id
-        // TODO Consider adding dynamic size 'payment.sender.fees.net' to operator hash
-        // payment.sender.fees.net
+        // TODO Consider adding dynamic size 'payment.sender.fees.total' to operator hash
+        // payment.sender.fees.total
     );
     const recipientHash = cryptography.hash(
         payment.recipient.nonce,
         payment.recipient.balances.current,
         payment.recipient.balances.previous
-        // TODO Consider adding dynamic size 'payment.recipient.fees.net' to operator hash
-        // payment.recipient.fees.net
+        // TODO Consider adding dynamic size 'payment.recipient.fees.total' to operator hash
+        // payment.recipient.fees.total
     );
     const transfersHash = cryptography.hash(
         payment.transfers.single,
-        payment.transfers.net
+        payment.transfers.total
     );
 
     return cryptography.hash(walletSignatureHash, nonceHash, senderHash, recipientHash, transfersHash);

--- a/test/scenarios/Exchange.js
+++ b/test/scenarios/Exchange.js
@@ -655,10 +655,10 @@ module.exports = (glob) => {
                             ethersClientFund.interface.events.StageEvent.topics[0]
                         ));
                         clientFundStageEvents.should.have.lengthOf(2);
-                        const stageNetFeeEvents = await provider.getLogs(await fromBlockTopicsFilter(
-                            ethersExchange.interface.events.StageNetFeeEvent.topics[0]
+                        const stageTotalFeeEvents = await provider.getLogs(await fromBlockTopicsFilter(
+                            ethersExchange.interface.events.StageTotalFeeEvent.topics[0]
                         ));
-                        stageNetFeeEvents.should.have.lengthOf(1);
+                        stageTotalFeeEvents.should.have.lengthOf(1);
                         const settleDriipEvents = await provider.getLogs(await fromBlockTopicsFilter(
                             ethersExchange.interface.events.SettleDriipAsTradeEvent.topics[0]
                         ));
@@ -693,12 +693,12 @@ module.exports = (glob) => {
                         conjugateHoldingStage[3].should.equal(trade.currencies.conjugate.ct);
                         conjugateHoldingStage[4]._bn.should.eq.BN(trade.currencies.conjugate.id._bn);
 
-                        const netFeeStage = await ethersClientFund._stages(2);
-                        netFeeStage[0].should.equal(trade.buyer.wallet);
-                        netFeeStage[1].should.equal(utils.getAddress(ethersRevenueFund.address));
-                        netFeeStage[2]._bn.should.eq.BN(trade.buyer.fees.net[0].amount._bn);
-                        netFeeStage[3].should.equal(trade.buyer.fees.net[0].currency.ct);
-                        netFeeStage[4]._bn.should.eq.BN(trade.buyer.fees.net[0].currency.id._bn);
+                        const totalFeeStage = await ethersClientFund._stages(2);
+                        totalFeeStage[0].should.equal(trade.buyer.wallet);
+                        totalFeeStage[1].should.equal(utils.getAddress(ethersRevenueFund.address));
+                        totalFeeStage[2]._bn.should.eq.BN(trade.buyer.fees.total[0].amount._bn);
+                        totalFeeStage[3].should.equal(trade.buyer.fees.total[0].currency.ct);
+                        totalFeeStage[4]._bn.should.eq.BN(trade.buyer.fees.total[0].currency.id._bn);
 
                         const nBuyerSettlements = await ethersExchange.settlementsCountByWallet(trade.buyer.wallet);
                         const buyerSettlementByIndex = await ethersExchange.settlementByWalletAndIndex(trade.buyer.wallet, nBuyerSettlements.sub(1));
@@ -928,10 +928,10 @@ module.exports = (glob) => {
                             ethersClientFund.interface.events.StageEvent.topics[0]
                         ));
                         clientFundStageEvents.should.have.lengthOf(1);
-                        const stageNetFeeEvents = await provider.getLogs(await fromBlockTopicsFilter(
-                            ethersExchange.interface.events.StageNetFeeEvent.topics[0]
+                        const stageTotalFeeEvents = await provider.getLogs(await fromBlockTopicsFilter(
+                            ethersExchange.interface.events.StageTotalFeeEvent.topics[0]
                         ));
-                        stageNetFeeEvents.should.have.lengthOf(1);
+                        stageTotalFeeEvents.should.have.lengthOf(1);
                         const settleDriipEvents = await provider.getLogs(await fromBlockTopicsFilter(
                             ethersExchange.interface.events.SettleDriipAsPaymentEvent.topics[0]
                         ));
@@ -953,12 +953,12 @@ module.exports = (glob) => {
                         holdingStage[3].should.equal(payment.currency.ct);
                         holdingStage[4]._bn.should.eq.BN(payment.currency.id._bn);
 
-                        const netFeeStage = await ethersClientFund._stages(1);
-                        netFeeStage[0].should.equal(payment.sender.wallet);
-                        netFeeStage[1].should.equal(utils.getAddress(ethersRevenueFund.address));
-                        netFeeStage[2]._bn.should.eq.BN(payment.sender.fees.net[0].amount._bn);
-                        netFeeStage[3].should.equal(payment.sender.fees.net[0].currency.ct);
-                        netFeeStage[4]._bn.should.eq.BN(payment.sender.fees.net[0].currency.id._bn);
+                        const totalFeeStage = await ethersClientFund._stages(1);
+                        totalFeeStage[0].should.equal(payment.sender.wallet);
+                        totalFeeStage[1].should.equal(utils.getAddress(ethersRevenueFund.address));
+                        totalFeeStage[2]._bn.should.eq.BN(payment.sender.fees.total[0].amount._bn);
+                        totalFeeStage[3].should.equal(payment.sender.fees.total[0].currency.ct);
+                        totalFeeStage[4]._bn.should.eq.BN(payment.sender.fees.total[0].currency.id._bn);
 
                         const nSenderSettlements = await ethersExchange.settlementsCountByWallet(payment.sender.wallet);
                         const senderSettlementByIndex = await ethersExchange.settlementByWalletAndIndex(payment.sender.wallet, nSenderSettlements.sub(1));

--- a/test/scenarios/FraudChallengeByPaymentSucceedingTrade.js
+++ b/test/scenarios/FraudChallengeByPaymentSucceedingTrade.js
@@ -471,9 +471,9 @@ module.exports = (glob) => {
                 });
             });
 
-            describe('if not genuine successive net fees', () => {
+            describe('if not genuine successive total fees', () => {
                 beforeEach(async () => {
-                    await ethersValidator.setGenuineSuccessiveTradePaymentNetFees(false);
+                    await ethersValidator.setGenuineSuccessiveTradePaymentTotalFees(false);
                 });
 
                 it('should set operational mode exit, store fraudulent payment and seize buyer\'s funds', async () => {

--- a/test/scenarios/FraudChallengeBySuccessivePayments.js
+++ b/test/scenarios/FraudChallengeBySuccessivePayments.js
@@ -434,9 +434,9 @@ module.exports = (glob) => {
                 });
             });
 
-            describe('if not genuine successive payments\' net fees', () => {
+            describe('if not genuine successive payments\' total fees', () => {
                 beforeEach(async () => {
-                    await ethersValidator.setGenuineSuccessivePaymentsNetFees(false);
+                    await ethersValidator.setGenuineSuccessivePaymentsTotalFees(false);
                 });
 
                 it('should set operational mode exit, store fraudulent payment and seize sender\'s funds', async () => {

--- a/test/scenarios/FraudChallengeBySuccessiveTrades.js
+++ b/test/scenarios/FraudChallengeBySuccessiveTrades.js
@@ -469,9 +469,9 @@ module.exports = (glob) => {
                 });
             });
 
-            describe('if not genuine successive trades\' net fees', () => {
+            describe('if not genuine successive trades\' total fees', () => {
                 beforeEach(async () => {
-                    await ethersValidator.setGenuineSuccessiveTradesNetFees(false);
+                    await ethersValidator.setGenuineSuccessiveTradesTotalFees(false);
                 });
 
                 it('should set operational mode exit, store fraudulent trade and seize buyer\'s funds', async () => {

--- a/test/scenarios/FraudChallengeByTradeSucceedingPayment.js
+++ b/test/scenarios/FraudChallengeByTradeSucceedingPayment.js
@@ -462,9 +462,9 @@ module.exports = (glob) => {
                 });
             });
 
-            describe('if not genuine successive net fees', () => {
+            describe('if not genuine successive total fees', () => {
                 beforeEach(async () => {
-                    await ethersValidator.setGenuineSuccessivePaymentTradeNetFees(false);
+                    await ethersValidator.setGenuineSuccessivePaymentTradeTotalFees(false);
                 });
 
                 it('should set operational mode exit, store fraudulent trade and seize buyer\'s funds', async () => {

--- a/test/scenarios/Validator.js
+++ b/test/scenarios/Validator.js
@@ -1952,7 +1952,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -1978,7 +1978,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.2', 18),
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -1986,11 +1986,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -2031,7 +2031,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -2057,7 +2057,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.2', 18),
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -2065,11 +2065,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -2110,7 +2110,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -2136,7 +2136,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.2', 18),
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -2144,11 +2144,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -2177,7 +2177,7 @@ module.exports = function (glob) {
         //         });
         //     });
         //
-        //     describe('if trade party\'s net fee in last trade is not incremented by single fee in last trade relative to net fee in first trade', () => {
+        //     describe('if trade party\'s total fee in last trade is not incremented by single fee in last trade relative to total fee in first trade', () => {
         //         beforeEach(async () => {
         //             lastTrade = await mocks.mockTrade(glob.owner, {
         //                 nonce: utils.bigNumberify(20),
@@ -2202,7 +2202,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -2228,7 +2228,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.4', 18), // <---- modified ----
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -2236,11 +2236,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -2300,7 +2300,7 @@ module.exports = function (glob) {
         //                     current: utils.parseUnits('19649.9', 18),
         //                     previous: utils.parseUnits('19700', 18)
         //                 },
-        //                 netFee: utils.parseUnits('0.1', 18)
+        //                 totalFee: utils.parseUnits('0.1', 18)
         //             },
         //             recipient: {
         //                 wallet: glob.user_a,
@@ -2309,7 +2309,7 @@ module.exports = function (glob) {
         //                     current: utils.parseUnits('9449.8', 18),
         //                     previous: utils.parseUnits('9399.8', 18)
         //                 },
-        //                 netFee: utils.parseUnits('0.2', 18)
+        //                 totalFee: utils.parseUnits('0.2', 18)
         //             },
         //             singleFee: utils.parseUnits('0.1', 18),
         //             blockNumber: utils.bigNumberify(blockNumber10)
@@ -2334,7 +2334,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19649.9', 18),
         //                         previous: utils.parseUnits('19700', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2343,11 +2343,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9449.8', 18),
         //                         previous: utils.parseUnits('9399.8', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.2', 18)
+        //                     totalFee: utils.parseUnits('0.2', 18)
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2371,7 +2371,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19649.9', 18),
         //                         previous: utils.parseUnits('19700', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2380,11 +2380,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9449.8', 18),
         //                         previous: utils.parseUnits('9399.8', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.2', 18)
+        //                     totalFee: utils.parseUnits('0.2', 18)
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2408,7 +2408,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19649.9', 18),
         //                         previous: utils.parseUnits('19700', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2417,11 +2417,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9449.8', 18),
         //                         previous: utils.parseUnits('1000', 18) // <---- modified ----
         //                     },
-        //                     netFee: utils.parseUnits('0.2', 18)
+        //                     totalFee: utils.parseUnits('0.2', 18)
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2446,7 +2446,7 @@ module.exports = function (glob) {
         //         });
         //     });
         //
-        //     describe('if payment party\'s net fee in last payment is not incremented by single fee in last payment relative to net fee in first payment', () => {
+        //     describe('if payment party\'s total fee in last payment is not incremented by single fee in last payment relative to total fee in first payment', () => {
         //         beforeEach(async () => {
         //             lastPayment = await mocks.mockPayment(glob.owner, {
         //                 nonce: utils.bigNumberify(20),
@@ -2458,7 +2458,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19649.9', 18),
         //                         previous: utils.parseUnits('19700', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2467,11 +2467,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9449.8', 18),
         //                         previous: utils.parseUnits('9399.8', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.4', 18) // <---- modified ----
+        //                     totalFee: utils.parseUnits('0.4', 18) // <---- modified ----
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2538,7 +2538,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19449.9', 18),
         //                         previous: utils.parseUnits('19500', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2547,11 +2547,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9649.8', 18),
         //                         previous: utils.parseUnits('9599.8', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.2', 18)
+        //                     totalFee: utils.parseUnits('0.2', 18)
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2575,7 +2575,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19449.9', 18),
         //                         previous: utils.parseUnits('19500', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2584,11 +2584,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9649.8', 18),
         //                         previous: utils.parseUnits('9599.8', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.2', 18)
+        //                     totalFee: utils.parseUnits('0.2', 18)
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2612,7 +2612,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19449.9', 18),
         //                         previous: utils.parseUnits('19500', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2621,11 +2621,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9649.8', 18),
         //                         previous: utils.parseUnits('1000', 18) // <---- modified ----
         //                     },
-        //                     netFee: utils.parseUnits('0.2', 18)
+        //                     totalFee: utils.parseUnits('0.2', 18)
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2650,7 +2650,7 @@ module.exports = function (glob) {
         //         });
         //     });
         //
-        //     describe('if payment party\'s net fee in payment is not incremented by single fee in payment relative to net fee in trade', () => {
+        //     describe('if payment party\'s total fee in payment is not incremented by single fee in payment relative to total fee in trade', () => {
         //         beforeEach(async () => {
         //             payment = await mocks.mockPayment(glob.owner, {
         //                 nonce: utils.bigNumberify(20),
@@ -2662,7 +2662,7 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('19449.9', 18),
         //                         previous: utils.parseUnits('19500', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.1', 18)
+        //                     totalFee: utils.parseUnits('0.1', 18)
         //                 },
         //                 recipient: {
         //                     wallet: glob.user_a,
@@ -2671,11 +2671,11 @@ module.exports = function (glob) {
         //                         current: utils.parseUnits('9649.8', 18),
         //                         previous: utils.parseUnits('9599.8', 18)
         //                     },
-        //                     netFee: utils.parseUnits('0.4', 18) // <---- modified ----
+        //                     totalFee: utils.parseUnits('0.4', 18) // <---- modified ----
         //                 },
         //                 transfers: {
         //                     single: utils.parseUnits('50', 18),
-        //                     net: utils.parseUnits('-50', 18)
+        //                     total: utils.parseUnits('-50', 18)
         //                 },
         //                 singleFee: utils.parseUnits('0.1', 18),
         //                 blockNumber: utils.bigNumberify(blockNumber10)
@@ -2755,7 +2755,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -2781,7 +2781,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.2', 18),
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -2789,11 +2789,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -2834,7 +2834,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -2860,7 +2860,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.2', 18),
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -2868,11 +2868,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -2913,7 +2913,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -2939,7 +2939,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.2', 18),
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -2947,11 +2947,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -2980,7 +2980,7 @@ module.exports = function (glob) {
         //         });
         //     });
         //
-        //     describe('if trade party\'s net fee in trade is not incremented by single fee in trade relative to net fee in payment', () => {
+        //     describe('if trade party\'s total fee in trade is not incremented by single fee in trade relative to total fee in payment', () => {
         //         beforeEach(async () => {
         //             trade = await mocks.mockTrade(glob.owner, {
         //                 nonce: utils.bigNumberify(20),
@@ -3005,7 +3005,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.1', 18),
         //                         conjugate: utils.parseUnits('0.0004', 18)
         //                     }
@@ -3031,7 +3031,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.4', 18), // <---- modified ----
         //                         conjugate: utils.parseUnits('0.00005', 18)
         //                     }
@@ -3039,11 +3039,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('50', 18),
-        //                         net: utils.parseUnits('-50', 18)
+        //                         total: utils.parseUnits('-50', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.05', 18),
-        //                         net: utils.parseUnits('-0.05', 18)
+        //                         total: utils.parseUnits('-0.05', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -3130,7 +3130,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.3', 18),
         //                         conjugate: utils.parseUnits('0.0', 18)
         //                     }
@@ -3159,7 +3159,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.0', 18),
         //                         conjugate: utils.parseUnits('0.0006', 18)
         //                     }
@@ -3167,11 +3167,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('100', 18),
-        //                         net: utils.parseUnits('300', 18)
+        //                         total: utils.parseUnits('300', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.1', 18),
-        //                         net: utils.parseUnits('0.3', 18)
+        //                         total: utils.parseUnits('0.3', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -3215,7 +3215,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.3', 18),
         //                         conjugate: utils.parseUnits('0.0', 18)
         //                     }
@@ -3244,7 +3244,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.0', 18),
         //                         conjugate: utils.parseUnits('0.0006', 18)
         //                     }
@@ -3252,11 +3252,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('100', 18),
-        //                         net: utils.parseUnits('300', 18)
+        //                         total: utils.parseUnits('300', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.1', 18),
-        //                         net: utils.parseUnits('0.3', 18)
+        //                         total: utils.parseUnits('0.3', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -3300,7 +3300,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.3', 18),
         //                         conjugate: utils.parseUnits('0.0', 18)
         //                     }
@@ -3329,7 +3329,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.0', 18),
         //                         conjugate: utils.parseUnits('0.0006', 18)
         //                     }
@@ -3337,11 +3337,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('100', 18),
-        //                         net: utils.parseUnits('300', 18)
+        //                         total: utils.parseUnits('300', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.1', 18),
-        //                         net: utils.parseUnits('0.3', 18)
+        //                         total: utils.parseUnits('0.3', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -3385,7 +3385,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.3', 18),
         //                         conjugate: utils.parseUnits('0.0', 18)
         //                     }
@@ -3414,7 +3414,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.0', 18),
         //                         conjugate: utils.parseUnits('0.0006', 18)
         //                     }
@@ -3422,11 +3422,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('100', 18),
-        //                         net: utils.parseUnits('300', 18)
+        //                         total: utils.parseUnits('300', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.1', 18),
-        //                         net: utils.parseUnits('0.3', 18)
+        //                         total: utils.parseUnits('0.3', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -3508,7 +3508,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.3', 18),
         //                         conjugate: utils.parseUnits('0.0', 18)
         //                     }
@@ -3534,7 +3534,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.0', 18),
         //                         conjugate: utils.parseUnits('0.0006', 18)
         //                     }
@@ -3542,11 +3542,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('100', 18),
-        //                         net: utils.parseUnits('300', 18)
+        //                         total: utils.parseUnits('300', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.1', 18),
-        //                         net: utils.parseUnits('0.3', 18)
+        //                         total: utils.parseUnits('0.3', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -3590,7 +3590,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.3', 18),
         //                         conjugate: utils.parseUnits('0.0', 18)
         //                     }
@@ -3616,7 +3616,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.0', 18),
         //                         conjugate: utils.parseUnits('0.0006', 18)
         //                     }
@@ -3624,11 +3624,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('100', 18),
-        //                         net: utils.parseUnits('300', 18)
+        //                         total: utils.parseUnits('300', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.1', 18),
-        //                         net: utils.parseUnits('0.3', 18)
+        //                         total: utils.parseUnits('0.3', 18)
         //                     }
         //                 },
         //                 singleFees: {
@@ -3679,7 +3679,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('9.4', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.3', 18),
         //                         conjugate: utils.parseUnits('0.0', 18)
         //                     }
@@ -3708,7 +3708,7 @@ module.exports = function (glob) {
         //                             previous: utils.parseUnits('19.6996', 18)
         //                         }
         //                     },
-        //                     netFees: {
+        //                     totalFees: {
         //                         intended: utils.parseUnits('0.0', 18),
         //                         conjugate: utils.parseUnits('0.0006', 18)
         //                     }
@@ -3716,11 +3716,11 @@ module.exports = function (glob) {
         //                 transfers: {
         //                     intended: {
         //                         single: utils.parseUnits('100', 18),
-        //                         net: utils.parseUnits('300', 18)
+        //                         total: utils.parseUnits('300', 18)
         //                     },
         //                     conjugate: {
         //                         single: utils.parseUnits('0.1', 18),
-        //                         net: utils.parseUnits('0.3', 18)
+        //                         total: utils.parseUnits('0.3', 18)
         //                     }
         //                 },
         //                 singleFees: {


### PR DESCRIPTION
Replacement of the term 'net' by 'total' in the contexts of fees and transfers.